### PR TITLE
Using us-east-1b as default region for terraform

### DIFF
--- a/slides/unit2.html
+++ b/slides/unit2.html
@@ -58,7 +58,7 @@ aws ec2 import-key-pair --key-name <mark>[key name]</mark> \
 
 resource "aws_subnet" "public_subnet_1" {
     vpc_id = "${aws_vpc.workshop_vpc.id}"
-    availability_zone = "us-east-1a"
+    availability_zone = "us-east-1b"
     cidr_block = "<mark>10.0.X.0/26</mark>"
 }
 

--- a/slides/unit6.html
+++ b/slides/unit6.html
@@ -110,7 +110,7 @@ EOF
 				  In <code>networks.tf</code>
 				  <pre><code data-noescape>resource "aws_subnet" "db_subnet_1" {
     vpc_id = "${aws_vpc.workshop_vpc.id}"
-    availability_zone = "us-east-1a"
+    availability_zone = "us-east-1b"
     cidr_block = "<mark>10.0.X.128/26</mark>"
     map_public_ip_on_launch = false
 }


### PR DESCRIPTION
AWS does not entertain VPC requests in us-east-1a so changing the default region in config to be a different one. With us-east-1a first run results in an error where participants see an error being returned by Terraform config that `Value (us-east-1a) for parameter availabilityZone is invalid. Subnets can currently only be created in the following availability zones: us-east-1c, us-east-1d, us-east-1b`.

This commit fixes the two places where us-east-1a has been explicitly referenced as one of the regions.